### PR TITLE
Boost req decreased to 1.48 for #138

### DIFF
--- a/azmq/detail/socket_service.hpp
+++ b/azmq/detail/socket_service.hpp
@@ -645,7 +645,7 @@ namespace detail {
             }
 
             friend
-            bool asio_handler_is_continuation(deferred_completion* handler) { return true; }
+            bool asio_handler_is_continuation(deferred_completion* /*handler*/) { return true; }
         };
 
         descriptor_map descriptors_;

--- a/azmq/detail/socket_service.hpp
+++ b/azmq/detail/socket_service.hpp
@@ -326,9 +326,9 @@ namespace detail {
             return ec;
         }
 
-        boost::system::error_code shutdown(implementation_type & impl,
-                                           shutdown_type what,
-                                           boost::system::error_code & ec) {
+        boost::system::error_code descriptor_shutdown(implementation_type & impl,
+                                                      shutdown_type what,
+                                                      boost::system::error_code & ec) {
             unique_lock l{ *impl };
             if (impl->shutdown_ < what)
                 impl->shutdown_ = what;

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -607,7 +607,7 @@ public:
      */
     boost::system::error_code shutdown(shutdown_type what,
                                        boost::system::error_code & ec) {
-        return get_service().shutdown(get_implementation(), what, ec);
+        return get_service().descriptor_shutdown(get_implementation(), what, ec);
     }
 
     /** \brief Initiate shutdown of socket


### PR DESCRIPTION
There are some incompatibilities with earlier Boost versions:
1. No BOOST_SYSTEM_NOEXCEPT before 1.54
2. No BOOST_NOEXCEPT (typically before 1.50)
3. No boost::utility::string_ref before 1.53
4. No boost log component in 1.48 and it is not referenced in AZMQ sources.

Proposed pull request fixes these incompatibilities making AZMQ useful with Boost down to 1.48.